### PR TITLE
Add support to  $TERM=tmux or tmux-256color

### DIFF
--- a/lib/imgcat.go
+++ b/lib/imgcat.go
@@ -42,7 +42,15 @@ func CatFile(fileName string, w io.Writer) error {
 
 func embed(r io.Reader, w io.Writer) error {
 
-	inScreen := os.Getenv("TERM") == "screen"
+	var inScreen bool
+	switch os.Getenv("TERM") {
+	case
+		"screen",
+		"tmux-256color":
+		inScreen = true
+	default:
+		inScreen = false
+	}
 
 	buf := new(bytes.Buffer)
 	_, err := buf.ReadFrom(r)

--- a/lib/imgcat.go
+++ b/lib/imgcat.go
@@ -46,6 +46,7 @@ func embed(r io.Reader, w io.Writer) error {
 	switch os.Getenv("TERM") {
 	case
 		"screen",
+		"tmux",
 		"tmux-256color":
 		inScreen = true
 	default:


### PR DESCRIPTION
Trigger tmux escaping in case where `TERM` environment variable equals `screen`, `tmux` or `tmux-256color`.

Rationale:
The current implementation supports tmux, but expects `$TERM` to be set to `screen`. Per tmux man page, `$TERM` can also be set to `tmux`. 

> The TERM environment variable must be set to `screen` or `tmux` for all programs running inside tmux.
https://man7.org/linux/man-pages/man1/tmux.1.html

It also seems that depending on the installed terminfo database (depends on ncurses version?), `$TERM` can be set to `tmux-256color`. 

https://invisible-island.net/ncurses/terminfo.src-entries.html#tic-tmux-256color

I've checked that at least the following configurations report $TERM `tmux-256color`.  

- Ubuntu 20.04,  ncurses 6.4, tmux 3.4
- Ubuntu 20.04, ncurses 6.2, tmux 3.5
- Arch, ncurses 6.5, tmux 3.5 
